### PR TITLE
Exclude shared pool tests

### DIFF
--- a/test/e2e_node/podresources_test.go
+++ b/test/e2e_node/podresources_test.go
@@ -185,6 +185,9 @@ func matchPodDescWithResources(expected []podDesc, found podResMap) error {
 			if isIntegral(podReq.cpuRequest) && len(cntInfo.CpuIds) != int(podReq.cpuRequest) {
 				return fmt.Errorf("pod %q container %q expected %f cpus got %v", podReq.podName, podReq.cntName, podReq.cpuRequest, cntInfo.CpuIds)
 			}
+			if !isIntegral(podReq.cpuRequest) && len(cntInfo.CpuIds) != 0 {
+				return fmt.Errorf("pod %q container %q requested %f expected to be allocated CPUs from shared pool %v", podReq.podName, podReq.cntName, podReq.cpuRequest, cntInfo.CpuIds)
+			}
 		}
 		if podReq.resourceName != "" && podReq.resourceAmount > 0 {
 			dev := findContainerDeviceByName(cntInfo.GetDevices(), podReq.resourceName)
@@ -437,6 +440,38 @@ func podresourcesListTests(f *framework.Framework, cli kubeletpodresourcesv1.Pod
 	expectedPostDelete := filterOutDesc(expected, "pod-01")
 	expectPodResources(1, cli, expectedPostDelete)
 	tpd.deletePodsForTest(f)
+
+	tpd = newTestPodData()
+	ginkgo.By("checking the output when pods request non integral CPUs")
+	if sd != nil {
+		expected = []podDesc{
+			{
+				podName:    "pod-00",
+				cntName:    "cnt-00",
+				cpuRequest: 1.5,
+			},
+			{
+				podName:        "pod-01",
+				cntName:        "cnt-00",
+				resourceName:   sd.resourceName,
+				resourceAmount: 1,
+				cpuRequest:     1.5,
+			},
+		}
+	} else {
+		expected = []podDesc{
+			{
+				podName:    "pod-00",
+				cntName:    "cnt-00",
+				cpuRequest: 1.5,
+			},
+		}
+
+	}
+	tpd.createPodsForTest(f, expected)
+	expectPodResources(1, cli, expected)
+	tpd.deletePodsForTest(f)
+
 }
 
 func podresourcesGetAllocatableResourcesTests(f *framework.Framework, cli kubeletpodresourcesv1.PodResourcesListerClient, sd *sriovData, onlineCPUs, reservedSystemCPUs cpuset.CPUSet) {

--- a/test/e2e_node/podresources_test.go
+++ b/test/e2e_node/podresources_test.go
@@ -48,7 +48,7 @@ type podDesc struct {
 	cntName        string
 	resourceName   string
 	resourceAmount int
-	cpuCount       int
+	cpuRequest     float32
 }
 
 func makePodResourcesTestPod(desc podDesc) *v1.Pod {
@@ -61,9 +61,9 @@ func makePodResourcesTestPod(desc podDesc) *v1.Pod {
 		},
 		Command: []string{"sh", "-c", "sleep 1d"},
 	}
-	if desc.cpuCount > 0 {
-		cnt.Resources.Requests[v1.ResourceCPU] = resource.MustParse(fmt.Sprintf("%d", desc.cpuCount))
-		cnt.Resources.Limits[v1.ResourceCPU] = resource.MustParse(fmt.Sprintf("%d", desc.cpuCount))
+	if desc.cpuRequest > 0 {
+		cnt.Resources.Requests[v1.ResourceCPU] = resource.MustParse(fmt.Sprintf("%f", desc.cpuRequest))
+		cnt.Resources.Limits[v1.ResourceCPU] = resource.MustParse(fmt.Sprintf("%f", desc.cpuRequest))
 		// we don't really care, we only need to be in guaranteed QoS
 		cnt.Resources.Requests[v1.ResourceMemory] = resource.MustParse("100Mi")
 		cnt.Resources.Limits[v1.ResourceMemory] = resource.MustParse("100Mi")
@@ -181,13 +181,11 @@ func matchPodDescWithResources(expected []podDesc, found podResMap) error {
 		if !ok {
 			return fmt.Errorf("no container resources for pod %q container %q", podReq.podName, podReq.cntName)
 		}
-
-		if podReq.cpuCount > 0 {
-			if len(cntInfo.CpuIds) != podReq.cpuCount {
-				return fmt.Errorf("pod %q container %q expected %d cpus got %v", podReq.podName, podReq.cntName, podReq.cpuCount, cntInfo.CpuIds)
+		if podReq.cpuRequest > 0 {
+			if isIntegral(podReq.cpuRequest) && len(cntInfo.CpuIds) != int(podReq.cpuRequest) {
+				return fmt.Errorf("pod %q container %q expected %f cpus got %v", podReq.podName, podReq.cntName, podReq.cpuRequest, cntInfo.CpuIds)
 			}
 		}
-
 		if podReq.resourceName != "" && podReq.resourceAmount > 0 {
 			dev := findContainerDeviceByName(cntInfo.GetDevices(), podReq.resourceName)
 			if dev == nil {
@@ -269,19 +267,19 @@ func podresourcesListTests(f *framework.Framework, cli kubeletpodresourcesv1.Pod
 				cntName:        "cnt-00",
 				resourceName:   sd.resourceName,
 				resourceAmount: 1,
-				cpuCount:       2,
+				cpuRequest:     2,
 			},
 			{
-				podName:  "pod-02",
-				cntName:  "cnt-00",
-				cpuCount: 2,
+				podName:    "pod-02",
+				cntName:    "cnt-00",
+				cpuRequest: 2,
 			},
 			{
 				podName:        "pod-03",
 				cntName:        "cnt-00",
 				resourceName:   sd.resourceName,
 				resourceAmount: 1,
-				cpuCount:       1,
+				cpuRequest:     1,
 			},
 		}
 	} else {
@@ -291,19 +289,19 @@ func podresourcesListTests(f *framework.Framework, cli kubeletpodresourcesv1.Pod
 				cntName: "cnt-00",
 			},
 			{
-				podName:  "pod-01",
-				cntName:  "cnt-00",
-				cpuCount: 2,
+				podName:    "pod-01",
+				cntName:    "cnt-00",
+				cpuRequest: 2,
 			},
 			{
-				podName:  "pod-02",
-				cntName:  "cnt-00",
-				cpuCount: 2,
+				podName:    "pod-02",
+				cntName:    "cnt-00",
+				cpuRequest: 2,
 			},
 			{
-				podName:  "pod-03",
-				cntName:  "cnt-00",
-				cpuCount: 1,
+				podName:    "pod-03",
+				cntName:    "cnt-00",
+				cpuRequest: 1,
 			},
 		}
 
@@ -325,12 +323,12 @@ func podresourcesListTests(f *framework.Framework, cli kubeletpodresourcesv1.Pod
 				cntName:        "cnt-00",
 				resourceName:   sd.resourceName,
 				resourceAmount: 1,
-				cpuCount:       2,
+				cpuRequest:     2,
 			},
 			{
-				podName:  "pod-02",
-				cntName:  "cnt-00",
-				cpuCount: 2,
+				podName:    "pod-02",
+				cntName:    "cnt-00",
+				cpuRequest: 2,
 			},
 		}
 	} else {
@@ -340,14 +338,14 @@ func podresourcesListTests(f *framework.Framework, cli kubeletpodresourcesv1.Pod
 				cntName: "cnt-00",
 			},
 			{
-				podName:  "pod-01",
-				cntName:  "cnt-00",
-				cpuCount: 2,
+				podName:    "pod-01",
+				cntName:    "cnt-00",
+				cpuRequest: 2,
 			},
 			{
-				podName:  "pod-02",
-				cntName:  "cnt-00",
-				cpuCount: 2,
+				podName:    "pod-02",
+				cntName:    "cnt-00",
+				cpuRequest: 2,
 			},
 		}
 	}
@@ -361,13 +359,13 @@ func podresourcesListTests(f *framework.Framework, cli kubeletpodresourcesv1.Pod
 			cntName:        "cnt-00",
 			resourceName:   sd.resourceName,
 			resourceAmount: 1,
-			cpuCount:       1,
+			cpuRequest:     1,
 		}
 	} else {
 		extra = podDesc{
-			podName:  "pod-03",
-			cntName:  "cnt-00",
-			cpuCount: 1,
+			podName:    "pod-03",
+			cntName:    "cnt-00",
+			cpuRequest: 1,
 		}
 
 	}
@@ -386,16 +384,16 @@ func podresourcesListTests(f *framework.Framework, cli kubeletpodresourcesv1.Pod
 	if sd != nil {
 		expected = []podDesc{
 			{
-				podName:  "pod-00",
-				cntName:  "cnt-00",
-				cpuCount: 1,
+				podName:    "pod-00",
+				cntName:    "cnt-00",
+				cpuRequest: 1,
 			},
 			{
 				podName:        "pod-01",
 				cntName:        "cnt-00",
 				resourceName:   sd.resourceName,
 				resourceAmount: 1,
-				cpuCount:       2,
+				cpuRequest:     2,
 			},
 			{
 				podName: "pod-02",
@@ -406,29 +404,29 @@ func podresourcesListTests(f *framework.Framework, cli kubeletpodresourcesv1.Pod
 				cntName:        "cnt-00",
 				resourceName:   sd.resourceName,
 				resourceAmount: 1,
-				cpuCount:       1,
+				cpuRequest:     1,
 			},
 		}
 	} else {
 		expected = []podDesc{
 			{
-				podName:  "pod-00",
-				cntName:  "cnt-00",
-				cpuCount: 1,
+				podName:    "pod-00",
+				cntName:    "cnt-00",
+				cpuRequest: 1,
 			},
 			{
-				podName:  "pod-01",
-				cntName:  "cnt-00",
-				cpuCount: 2,
+				podName:    "pod-01",
+				cntName:    "cnt-00",
+				cpuRequest: 1,
 			},
 			{
 				podName: "pod-02",
 				cntName: "cnt-00",
 			},
 			{
-				podName:  "pod-03",
-				cntName:  "cnt-00",
-				cpuCount: 1,
+				podName:    "pod-03",
+				cntName:    "cnt-00",
+				cpuRequest: 1,
 			},
 		}
 	}
@@ -738,4 +736,8 @@ func enablePodResourcesFeatureGateInKubelet(f *framework.Framework) (oldCfg *kub
 	}, time.Minute, time.Second).Should(gomega.BeTrue())
 
 	return oldCfg
+}
+
+func isIntegral(cpuRequest float32) bool {
+	return cpuRequest == float32(int(cpuRequest))
 }


### PR DESCRIPTION
- Change cpuCount to cpuRequest in order to cater to cases  where guaranteed pods make non-integral CPU Requests.
- Add e2e tests for test cases for pods with non-integral CPUs

Signed-off-by: Swati Sehgal <swsehgal@redhat.com>